### PR TITLE
Fix: Fix app crash due to port configuration

### DIFF
--- a/main.py
+++ b/main.py
@@ -305,4 +305,5 @@ def contact():
 
 
 if __name__ == "__main__":
-    app.run(host='0.0.0.0', port=5000, debug=False)
+    port = os.environ.get(key='PORT',default=5000)
+    app.run(host='0.0.0.0', port=port, debug=False)


### PR DESCRIPTION
App hosted on render, App preset port is different to what render sets it to. This caused server timeout only on hosted server.